### PR TITLE
Problem: can't compile pldotnet extension

### DIFF
--- a/src/pldotnet_conversions.h
+++ b/src/pldotnet_conversions.h
@@ -285,7 +285,7 @@ extern PGDLLEXPORT void pldotnet_GetDatumDateAttributes(void *datum, int *date);
  * @param time the int64 value that represents a Date in PostgreSQL.
  */
 extern PGDLLEXPORT void pldotnet_GetDatumTimeAttributes(void *datum,
-                                                        long *time);
+                                                        int64_t *time);
 
 /**
  * @brief Extracts the long and integer values corresponding to a PostgreSQL
@@ -297,7 +297,7 @@ extern PGDLLEXPORT void pldotnet_GetDatumTimeAttributes(void *datum,
  * @param zone the time zone.
  */
 extern PGDLLEXPORT void pldotnet_GetDatumTimeTzAttributes(void *datum,
-                                                          long *time,
+                                                          int64_t *time,
                                                           int *zone);
 
 /**
@@ -310,7 +310,7 @@ extern PGDLLEXPORT void pldotnet_GetDatumTimeTzAttributes(void *datum,
  * PostgreSQL.
  */
 extern PGDLLEXPORT void pldotnet_GetDatumTimestampAttributes(void *datum,
-                                                             long *timestamp);
+                                                             int64_t *timestamp);
 
 /**
  * @brief Extracts the long value corresponding to a PostgreSQL Timestamp with
@@ -322,7 +322,7 @@ extern PGDLLEXPORT void pldotnet_GetDatumTimestampAttributes(void *datum,
  * PostgreSQL.
  */
 extern PGDLLEXPORT void pldotnet_GetDatumTimestampTzAttributes(void *datum,
-                                                               long *timestamp);
+                                                               int64_t *timestamp);
 
 /**
  * @brief Extracts the time (number of ticks), day, and moth values from a
@@ -335,7 +335,7 @@ extern PGDLLEXPORT void pldotnet_GetDatumTimestampTzAttributes(void *datum,
  * @param month the month.
  */
 extern PGDLLEXPORT void pldotnet_GetDatumIntervalAttributes(void *datum,
-                                                            long *time,
+                                                            int64_t *time,
                                                             int *day,
                                                             int *month);
 
@@ -374,7 +374,7 @@ extern PGDLLEXPORT void pldotnet_GetDatumInetAttributes(void *datum, int *nelem,
  * @param value is the long integer that represents the PostgreSQL Money.
  */
 extern PGDLLEXPORT void pldotnet_GetDatumMoneyAttributes(void *datum,
-                                                         long *value);
+                                                         int64_t *value);
 
 /**
  * @brief Extracts the length and the memory address where the bits of a
@@ -713,7 +713,7 @@ extern PGDLLEXPORT Datum pldotnet_CreateDatumDate(int date);
  * @param time the long integer value that represents a Time in PostgreSQL.
  * @return Datum the datum object.
  */
-extern PGDLLEXPORT Datum pldotnet_CreateDatumTime(long time);
+extern PGDLLEXPORT Datum pldotnet_CreateDatumTime(int64_t time);
 
 /**
  * @brief Creates a PostgreSQL Time with the time zone. It is used to convert
@@ -723,7 +723,7 @@ extern PGDLLEXPORT Datum pldotnet_CreateDatumTime(long time);
  * @param zone the zone value.
  * @return Datum the datum object.
  */
-extern PGDLLEXPORT Datum pldotnet_CreateDatumTimeTz(long time, int zone);
+extern PGDLLEXPORT Datum pldotnet_CreateDatumTimeTz(int64_t time, int zone);
 
 /**
  * @brief Creates a PostgreSQL Timestamp without a time zone. It is used to
@@ -733,7 +733,7 @@ extern PGDLLEXPORT Datum pldotnet_CreateDatumTimeTz(long time, int zone);
  * PostgreSQL.
  * @return Datum the datum object.
  */
-extern PGDLLEXPORT Datum pldotnet_CreateDatumTimestamp(long timestamp);
+extern PGDLLEXPORT Datum pldotnet_CreateDatumTimestamp(int64_t timestamp);
 
 /**
  * @brief Creates a PostgreSQL Timestamp with the time zone. It is used to
@@ -743,7 +743,7 @@ extern PGDLLEXPORT Datum pldotnet_CreateDatumTimestamp(long timestamp);
  * PostgreSQL.
  * @return Datum the datum object.
  */
-extern PGDLLEXPORT Datum pldotnet_CreateDatumTimestampTz(long timestamp);
+extern PGDLLEXPORT Datum pldotnet_CreateDatumTimestampTz(int64_t timestamp);
 
 /**
  * @brief Creates a PostgreSQL Interval. It is used to convert from a .NET type
@@ -754,7 +754,7 @@ extern PGDLLEXPORT Datum pldotnet_CreateDatumTimestampTz(long timestamp);
  * @param month the number of months.
  * @return Datum the datum object.
  */
-extern PGDLLEXPORT Datum pldotnet_CreateDatumInterval(long time, int day,
+extern PGDLLEXPORT Datum pldotnet_CreateDatumInterval(int64_t time, int day,
                                                       int month);
 
 /**
@@ -788,7 +788,7 @@ extern PGDLLEXPORT Datum pldotnet_CreateDatumInet(int length,
  * @param value the long integer that represents the money in PostgreSQL
  * @return Datum the datum object.
  */
-extern PGDLLEXPORT Datum pldotnet_CreateDatumMoney(long value);
+extern PGDLLEXPORT Datum pldotnet_CreateDatumMoney(int64_t value);
 
 /**
  * @brief Creates a PostgreSQL VarBit or Bit. It is used to convert from a .NET

--- a/src/pldotnet_main.c
+++ b/src/pldotnet_main.c
@@ -603,7 +603,7 @@ static void srf_MemoryContextCallback(void *cbdp) {
                             NULL, 0, NULL, NULL);
     if (res != RETURN_SRF_DONE) {
         elog(WARNING,
-             "BAD: Got result (%d) from freeing call %u on function %lu", res,
+             "BAD: Got result (%d) from freeing call %u on function %llu", res,
              cbd->functionId, cbd->call_id);
     }
 }
@@ -938,8 +938,7 @@ static Datum pldotnet_CompileAndRunUserFunction(const FunctionCallInfo fcinfo,
                                           // find the enumerator in the cache
 
             // create and register the callback for garbage collection
-            cbd = (cb_data *)funcctx->multi_call_memory_ctx->methods->alloc(
-                funcctx->multi_call_memory_ctx, sizeof(cb_data));
+            cbd = (cb_data *)MemoryContextAlloc(funcctx->multi_call_memory_ctx, sizeof(cb_data));
 
             cbd->cb_record.arg = cbd;
             cbd->cb_record.func = srf_MemoryContextCallback;


### PR DESCRIPTION
Errors on mismatched function signatures.

Solution: ensure signatures match

Also, use public MemoryContext API for allocations.

While at it, fix a format string the compiler was complaining about.